### PR TITLE
Fixup craft-locate so it works with recent CraftCMS

### DIFF
--- a/src/assetbundles/locate/LocateAsset.php
+++ b/src/assetbundles/locate/LocateAsset.php
@@ -8,7 +8,7 @@
  * @copyright Copyright (c) 2018 Isaac Gray
  */
 
-namespace swixpop\locate\assetbundles\Locate;
+namespace swixpop\locate\assetbundles\locate;
 
 use Craft;
 use craft\web\AssetBundle;

--- a/src/assetbundles/locatefieldfield/dist/js/LocateField.js
+++ b/src/assetbundles/locatefieldfield/dist/js/LocateField.js
@@ -84,6 +84,9 @@
     // A really lightweight plugin wrapper around the constructor,
     // preventing against multiple instantiations
     $.fn[pluginName] = function (options) {
+        // Temporary fix for Locate to get the right prefix
+        options.prefix = options.namespace.replace(options.name, '');
+
         return this.each(function () {
             if (!$.data(this, "plugin_" + pluginName)) {
                 $.data(this, "plugin_" + pluginName,


### PR DESCRIPTION
This PR will fix #9 (and its duplicate #10) and will also preventatively fix #11.
Without it the plugin doesn't work any longer on recent versions of Craft CMS. With these changes merged, the plugin will function again.